### PR TITLE
スタイル微調整

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,14 +20,14 @@ export default async function RootLayout({
   return (
     <html lang="ja">
       <body>
-        <header className="fixed top-0 z-10 flex h-16 w-full items-center border-b border-b-neutral-300 px-24 backdrop-blur md:px-10">
+        <header className="fixed top-0 z-10 flex h-16 w-full items-center justify-center border-b border-b-neutral-300 backdrop-blur md:justify-start md:px-10">
           <Link href="/" className="text-xl font-bold">
             Frontend Book
           </Link>
         </header>
         <SideMenu articleIndexes={articleIndexes} />
         <main className="mt-16">
-          <article className="prose prose-neutral max-w-none break-all p-10 md:ml-64">
+          <article className="prose prose-neutral max-w-none break-all px-5 py-10 md:ml-64 md:px-10">
             {children}
           </article>
         </main>

--- a/src/components/side-menu.tsx
+++ b/src/components/side-menu.tsx
@@ -17,7 +17,7 @@ export function SideMenu({ articleIndexes }: Props) {
       <input
         id="menu-button"
         type="checkbox"
-        className="peer fixed left-6 top-0 z-10 h-16 w-16 appearance-none before:absolute before:right-5 before:top-8 before:block before:h-0.5 before:w-6 before:-translate-y-1 before:bg-black before:duration-500 after:absolute after:right-5 after:top-8 after:block after:h-0.5 after:w-6 after:translate-y-1 after:bg-black after:duration-500 checked:before:translate-y-0 checked:before:rotate-45 checked:after:translate-y-0 checked:after:-rotate-45 md:hidden"
+        className="peer fixed left-1 top-0 z-10 h-16 w-16 cursor-pointer appearance-none before:absolute before:right-5 before:top-8 before:block before:h-0.5 before:w-6 before:-translate-y-1 before:bg-black before:duration-500 after:absolute after:right-5 after:top-8 after:block after:h-0.5 after:w-6 after:translate-y-1 after:bg-black after:duration-500 checked:before:translate-y-0 checked:before:rotate-45 checked:after:translate-y-0 checked:after:-rotate-45 md:left-6 md:hidden"
       />
       <label
         htmlFor="menu-button"


### PR DESCRIPTION
## 概要

#24 
- SP時の左右の余白を20pxに変更
- メニューボタンに`cursor-pointer`を指定

| before | after |
|--------|--------|
| <img src="https://github.com/kanaru-ssk/frontend-book/assets/62755970/94b5fd5d-7089-4a36-b1fc-5cf66704913d" alt="before" width="280px" /> | <img src="https://github.com/kanaru-ssk/frontend-book/assets/62755970/551cc3d4-a5f1-48b9-8b74-08c244b68db8" alt="after" width="280px" /> | 

## やってないこと

Tabの表示崩れは未対応。別issueで対応する。
